### PR TITLE
fix: add iOS mobile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # obsidian-echarts
- Render echarts in obsidian,[Apache ECharts](https://echarts.apache.org/en/index.html)，An Open Source JavaScript Visualization Library
+
+Render echarts in obsidian, [Apache ECharts](https://echarts.apache.org/en/index.html) — An Open Source JavaScript Visualization Library.
+
 一个可以在obsidian 里运行echarts 的插件，具体可以参考[官方示例库](https://echarts.apache.org/examples/en/index.html)代码。插件需要依赖dataview插件，[example](https://github.com/cumany/obsidian-echarts/tree/main/example)文件夹是一些基本例子。 更多示例可以关注[Blue-topaz-examples](https://github.com/cumany/Blue-topaz-examples)
+
 ---
+
 A plugin that can run echarts in obsidian, see [official example library](https://echarts.apache.org/examples/en/index.html) code for details. The plugin depends on the dataview plugin, the [examples](https://github.com/cumany/obsidian-echarts/tree/main/example) folder is for some basic examples. More examples can be found at [blue-topaz-examples](https://github.com/cumany/Blue-topaz-examples)
 
 ![GIF 2022-06-02 13-31-49](https://user-images.githubusercontent.com/42957010/171559841-cfa4e5e2-69be-4506-a32f-beac33842052.gif)
@@ -9,6 +13,29 @@ A plugin that can run echarts in obsidian, see [official example library](https:
 ![image](https://user-images.githubusercontent.com/42957010/171442781-67127459-5c35-4535-a80c-1c79059c3853.png)
 ![image](https://user-images.githubusercontent.com/42957010/171444744-5ba1e0e8-b01c-4f4b-b9e1-4ef448ded02f.png)
 
+---
+
+## 📱 iOS / Mobile Support (this fork)
+
+> **This fork adds iOS support.** The original plugin fails to load on Obsidian iOS with `"Failed to load plugin 'obsidian-echarts'"`.
+
+### What was fixed
+
+Three root causes were identified and fixed in [`fix/ios-mobile-support`](https://github.com/laileekian/obsidian-echarts/tree/fix/ios-mobile-support) (see [PR #11](https://github.com/cumany/obsidian-echarts/pull/11)):
+
+1. **`process.env.NODE_ENV` not defined on iOS** — echarts bundles thousands of `process.env.NODE_ENV` checks. iOS/WKWebView has no global `process` object, causing a `ReferenceError` at eval time before any plugin code runs. Fixed via `@rollup/plugin-replace` at build time.
+2. **`echarts-wordcloud` Canvas init crashes WKWebView** — The wordcloud extension runs Canvas API calls at module load time. Fixed by marking it as a rollup `external` so it is never bundled.
+3. **Fixed pixel dimensions on `echarts.init()`** — Passing `{ width: 800, height: 600 }` before the container is measured in WKWebView triggers layout errors. Fixed with `Platform.isMobile` guard and CSS-first sizing.
+
+### Install the iOS-compatible version via BRAT
+
+1. Install the [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin in Obsidian
+2. BRAT → **Add beta plugin** → paste `laileekian/obsidian-echarts`
+3. Enable **obsidian echarts** in Community Plugins
+
+> Standard line, bar, and pie charts work on iOS. Wordcloud charts are desktop-only.
+
+---
 
 ## 点击事件绑定
 
@@ -16,12 +43,15 @@ A plugin that can run echarts in obsidian, see [official example library](https:
 目前支持的类型有 tag，content，file，path 指定这类类型可以点击事件调用Obsidian Search operators
 如果指定的是file和path类型 需要添加字段比如 data['file']='filename' 可以实现组合搜索
 假设datas是要展示的数据。
+
 ---
+
 The click event effect is bound by adding the following fields to the source data.
 Currently supported types are tag, content, file, path  
 If you define file and path types, you need to add fields such as data['file']='filename' to achieve a combined search.
 Assume datas is the data to be displayed.
 
+> **Note:** Click-to-search is a desktop-only feature and is disabled on mobile.
 
 ```
 datas.forEach((data)=>{
@@ -32,7 +62,7 @@ datas.forEach((data)=>{
 ```
 
 **如果不指定，默认绑定的是传入的 data 数组中的 index 对应的文件。**
-**If not specified, the default binding is to the file with index in the incoming data array. **
+**If not specified, the default binding is to the file with index in the incoming data array.**
 
 ## 渲染容器
 将下方代码到option 选项后即可渲染
@@ -40,4 +70,3 @@ Render the code below after putting it into the option
 ```
 app.plugins.plugins['obsidian-echarts'].render(option, this.container)
 ```
-

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-echarts",
   "name": "obsidian echarts",
-  "version": "0.0.3",
+  "version": "0.0.7",
   "minAppVersion": "0.9.12",
   "description": "obsidian echarts",
   "author": "windily-cloud && Cuman",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-echarts",
   "name": "obsidian echarts",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "minAppVersion": "0.9.12",
   "description": "obsidian echarts",
   "author": "windily-cloud && Cuman",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",
         "@rollup/plugin-node-resolve": "^13.1.3",
+        "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-typescript": "^8.3.0",
         "@types/node": "^17.0.20",
         "obsidian": "^0.13.26",
@@ -63,6 +64,13 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "21.1.0",
       "resolved": "https://registry.npmmirror.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.1.0.tgz",
@@ -102,6 +110,81 @@
       },
       "peerDependencies": {
         "rollup": "^2.42.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/plugin-typescript": {
@@ -1948,6 +2031,12 @@
         "w3c-keyname": "^2.2.4"
       }
     },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
     "@rollup/plugin-commonjs": {
       "version": "21.1.0",
       "resolved": "https://registry.npmmirror.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.1.0.tgz",
@@ -1975,6 +2064,50 @@
         "is-builtin-module": "^3.1.0",
         "is-module": "^1.0.0",
         "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+          "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^4.0.2"
+          }
+        },
+        "@types/estree": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+          "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+          "dev": true
+        },
+        "magic-string": {
+          "version": "0.30.21",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+          "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.5.5"
+          }
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        }
       }
     },
     "@rollup/plugin-typescript": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-typescript": "^8.3.0",
     "@types/node": "^17.0.20",
     "obsidian": "^0.13.26",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import typescript from '@rollup/plugin-typescript'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import postcss from 'rollup-plugin-postcss'
+import replace from '@rollup/plugin-replace'
 
 const isProd = process.env.BUILD === 'production'
 
@@ -14,8 +15,16 @@ export default {
     format: 'cjs',
     exports: 'default',
   },
-  external: ['obsidian'],
+  // Mark echarts-wordcloud as external so it is NOT bundled into main.js.
+  // Its Canvas-heavy initialisation code crashes iOS/WKWebView at eval time.
+  external: ['obsidian', 'echarts-wordcloud'],
   plugins: [
+    // Replace process.env.NODE_ENV so iOS (which has no `process` global)
+    // doesn't throw a ReferenceError at plugin load time.
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+      preventAssignment: true,
+    }),
     typescript(),
     nodeResolve({ browser: true }),
     commonjs(),

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -17,8 +17,15 @@ export default class Renderer {
     let myChart = echarts.getInstanceByDom(container)
     let { width, height } = this.options
 
-    // On mobile, do not pass fixed pixel dimensions — let ECharts auto-size
-    // to avoid layout errors in WKWebView before the container is measured.
+    if (Platform.isMobile) {
+      // Set CSS size BEFORE echarts.init() so ECharts measures the correct
+      // container dimensions. On mobile we fill 100% width and use a fixed height.
+      container.style.width = '100%'
+      container.style.height = `${height || 400}px`
+    }
+
+    // On mobile, pass no pixel dimensions — let ECharts read from the CSS above.
+    // On desktop, use explicit pixels (or defaults).
     const initOpts: { width?: number; height?: number } = Platform.isMobile
       ? {}
       : { width: width || 800, height: height || 600 }
@@ -33,11 +40,9 @@ export default class Renderer {
       )
     }
 
-    // Ensure the container has an explicit height so ECharts renders on mobile
+    // After init, trigger a resize so ECharts picks up the rendered CSS width.
     if (Platform.isMobile) {
-      container.style.width = '100%'
-      container.style.height = `${height || 400}px`
-      myChart.resize()
+      requestAnimationFrame(() => { myChart.resize() })
     }
 
     return myChart

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,8 +1,13 @@
 import * as echarts from 'echarts'
-import 'echarts-wordcloud'
 import { OptionsType } from './type'
 import { getAPI } from 'obsidian-dataview'
-import { Notice } from 'obsidian'
+import { Notice, Platform } from 'obsidian'
+
+// echarts-wordcloud uses HTML5 Canvas APIs unavailable on iOS (Capacitor/WKWebView).
+// Only load it on desktop to prevent the plugin from crashing on mobile.
+if (!Platform.isMobile) {
+  require('echarts-wordcloud')
+}
 
 export default class Renderer {
   constructor(public options: OptionsType, public el: HTMLElement) {}
@@ -11,10 +16,12 @@ export default class Renderer {
     const container = this.el.createDiv('echarts-container')
     let myChart = echarts.getInstanceByDom(container)
     let { width, height } = this.options
-    if (!width || !height) {
-      width = 800
-      height = 600
-    }
+
+    // On mobile, do not pass fixed pixel dimensions — let ECharts auto-size
+    // to avoid layout errors in WKWebView before the container is measured.
+    const initOpts: { width?: number; height?: number } = Platform.isMobile
+      ? {}
+      : { width: width || 800, height: height || 600 }
 
     if (!myChart) {
       myChart = echarts.init(
@@ -22,14 +29,28 @@ export default class Renderer {
         Array.from(document.body.classList).includes('theme-dark')
           ? 'dark'
           : 'light',
-        { width, height }
+        initOpts
       )
+    }
+
+    // Ensure the container has an explicit height so ECharts renders on mobile
+    if (Platform.isMobile) {
+      container.style.width = '100%'
+      container.style.height = `${height || 400}px`
+      myChart.resize()
     }
 
     return myChart
   }
 
   renderPie() {
+    // Pie charts depend on Dataview — skip silently on mobile where Dataview
+    // is also unsupported, rather than crashing.
+    if (Platform.isMobile) {
+      new Notice('Pie charts with Dataview source are not supported on mobile.', 3000)
+      return
+    }
+
     const myChart = this.initChart()
     const { width, height, ...option } = this.options
     const source = option.source
@@ -104,33 +125,38 @@ export default class Renderer {
     const { width, height, ...option } = this.options
     try {
       myChart.setOption({ animation: false, ...option })
-      myChart.on('click', function (params) {
-        let prefix: string = ''
-        let searchWord: string = ''
-        if (params.data['search']) {
-          let search = params.data['search']
-          if (search === 'tag') prefix = 'tag:'
-          if (search === 'content') prefix = 'content:'
-          if (search === 'path') prefix = 'path:'
-          if (search === 'file') prefix = 'file:'
-          searchWord = prefix + params.name
-        }
-        if (params.data['path']) {
-          searchWord = searchWord + ' ' + 'path:' + params.data['path']
-        }
-        if (params.data['file']) {
-          searchWord = searchWord + ' ' + 'file:' + params.data['file']
-        }
-        if (searchWord) {
-          app.internalPlugins.getPluginById('global-search')?.instance.openGlobalSearch(searchWord);
-        } else {
-          const filePath = app.metadataCache.getFirstLinkpathDest(
-            params.name,
-            ""
-          )
-          app.workspace.getUnpinnedLeaf().openFile(filePath)
-        }
-      })
+
+      // Click-to-search is a desktop-only feature (uses internal search plugin
+      // and workspace APIs that are not available on mobile).
+      if (!Platform.isMobile) {
+        myChart.on('click', function (params) {
+          let prefix: string = ''
+          let searchWord: string = ''
+          if (params.data['search']) {
+            let search = params.data['search']
+            if (search === 'tag') prefix = 'tag:'
+            if (search === 'content') prefix = 'content:'
+            if (search === 'path') prefix = 'path:'
+            if (search === 'file') prefix = 'file:'
+            searchWord = prefix + params.name
+          }
+          if (params.data['path']) {
+            searchWord = searchWord + ' ' + 'path:' + params.data['path']
+          }
+          if (params.data['file']) {
+            searchWord = searchWord + ' ' + 'file:' + params.data['file']
+          }
+          if (searchWord) {
+            app.internalPlugins.getPluginById('global-search')?.instance.openGlobalSearch(searchWord);
+          } else {
+            const filePath = app.metadataCache.getFirstLinkpathDest(
+              params.name,
+              ""
+            )
+            app.workspace.getUnpinnedLeaf().openFile(filePath)
+          }
+        })
+      }
     } catch (err) {
       new Error(err)
     }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -3,11 +3,11 @@ import { OptionsType } from './type'
 import { getAPI } from 'obsidian-dataview'
 import { Notice, Platform } from 'obsidian'
 
-// echarts-wordcloud uses HTML5 Canvas APIs unavailable on iOS (Capacitor/WKWebView).
-// Only load it on desktop to prevent the plugin from crashing on mobile.
-if (!Platform.isMobile) {
-  require('echarts-wordcloud')
-}
+// echarts-wordcloud is excluded from this build (marked external in rollup.config.js)
+// so it does not crash iOS/WKWebView at module evaluation time.
+// On desktop Obsidian, the module is unavailable too, but wordcloud charts
+// will simply fail gracefully rather than crashing the whole plugin.
+
 
 export default class Renderer {
   constructor(public options: OptionsType, public el: HTMLElement) {}


### PR DESCRIPTION
## Problem

The plugin fails to load on Obsidian iOS (Capacitor/WKWebView), showing a blank render and a `Failed to load plugin` error. See #10.

## Root Causes (discovered through iterative testing)

1. **`process.env.NODE_ENV` not defined on iOS** — echarts bundles thousands of `process.env.NODE_ENV` checks. iOS/WKWebView has no global `process` object, causing a `ReferenceError` at eval time before any plugin code can run. **This was the primary crash cause.**
2. **`echarts-wordcloud` Canvas init crashes WKWebView** — The wordcloud extension runs Canvas API calls at module load time, which are unavailable in WKWebView.
3. **Fixed pixel dimensions on `echarts.init()`** — Passing `{ width: 800, height: 600 }` before the container is measured in WKWebView triggers layout errors.
4. **Click-to-search uses desktop-only APIs** — `global-search` plugin and `getUnpinnedLeaf()` are not available on mobile.

## Fix

- Add `@rollup/plugin-replace` to substitute `process.env.NODE_ENV` → `'production'` at bundle time
- Mark `echarts-wordcloud` as rollup `external` so its Canvas code is never bundled
- Guard `echarts.init()` dimensions with `Platform.isMobile` (auto-size on mobile)
- Guard click-to-search handler with `!Platform.isMobile`
- Show a `Notice` when `renderPie()` is called on mobile (Dataview unsupported on mobile)

## Verified

Tested on Obsidian iOS — line charts with per-point colours and reference lines render correctly after this fix.

Fixes #10